### PR TITLE
Perform Ok-wrapping in `try_block` macro

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
     let result: Result<_, ()> = try_block! {
         let a = do_one(x)?;
         let b = do_two(a)?;
-        Ok(b)
+        b
     };
 
     println!("{:?}", result);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 /// and perform Ok-wrapping on the final value.
 ///
 /// #### Before:
-/// ```
+/// ```ignore
 /// let result: Result<T, E> = || {
 ///    let a = do_one(x)?;
 ///    let b = do_two(a)?;
@@ -11,7 +11,7 @@
 /// ```
 ///
 /// #### After:
-/// ```    
+/// ```ignore
 /// let result: Result<T, E> = try_block! {
 ///    let a = do_one(x)?;
 ///    let b = do_two(a)?;
@@ -22,9 +22,55 @@
 #[macro_export]
 macro_rules! try_block {
     { $($token:tt)* } => {{
-        ( || Ok (
+        ( || $crate::FromOk::from_ok(
             { $($token)* }
         ))()
     }}
 }
 
+/// A type that can Ok-wrap some value, for use in the [`try_block`] macro.
+pub trait FromOk {
+    type Ok;
+    /// Constructs the wrapped type from an ok value.
+    fn from_ok(val: Self::Ok) -> Self;
+}
+
+impl<T, E> FromOk for Result<T, E> {
+    type Ok = T;
+    #[inline]
+    fn from_ok(val: T) -> Self {
+        Ok(val)
+    }
+}
+
+impl<T> FromOk for Option<T> {
+    type Ok = T;
+    #[inline]
+    fn from_ok(val: T) -> Self {
+        Some(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn parse_sum() {
+        let result: Result<_, std::num::ParseIntError> = try_block! {
+            let x = "1".parse::<i32>()?;
+            let x = "2".parse::<i32>()? + x * 10;
+            let x = "3".parse::<i32>()? + x * 10;
+            x
+        };
+        assert_eq!(result, Ok(123));
+    }
+
+    #[test]
+    fn option() {
+        assert_eq!(
+            Some(520),
+            try_block! {
+                "400".parse::<i32>().ok()? + "20".parse::<i32>().ok()? * "6".parse::<i32>().ok()?
+            },
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 /// Macro to make your error-handling blocks (appear) lambda-less
+/// and perform Ok-wrapping on the final value.
 ///
 /// #### Before:
 /// ```
@@ -14,17 +15,16 @@
 /// let result: Result<T, E> = try_block! {
 ///    let a = do_one(x)?;
 ///    let b = do_two(a)?;
-///    Ok(b)
+///    b
 /// };
 /// ```
 
 #[macro_export]
 macro_rules! try_block {
     { $($token:tt)* } => {{
-        let l = || {
-            $($token)*
-        };
-        l()
+        ( || Ok (
+            { $($token)* }
+        ))()
     }}
 }
 


### PR DESCRIPTION
This modifies the macro to perform Ok-wrapping on the final value. Not only is this more ergonomic, this is how the full `try` block feature will behave when it is eventually stabilized: https://github.com/rust-lang/rust/issues/70941. Since this macro is meant to emulate the `try` block feature while we wait for stabilization, it makes sense that it should try to behave as closely to that feature as possible.

This will obviously be a breaking change, but since the crate has not reached 1.0 yet, that should not be a problem.